### PR TITLE
Remove erroneous text from head of main plugin file

### DIFF
--- a/livechat-wordpress.php
+++ b/livechat-wordpress.php
@@ -1,8 +1,4 @@
 
-Editing:  
-/home/livewp/public_html/wp-content/plugins/livechat-wordpress/livechat-wordpress.php
- Encoding:    Re-open Use Code Editor     Close  Save Changes
-
 <?php
 
 /*


### PR DESCRIPTION
Somehow, erroneous text was saved into the head of the main plugin PHP file, causing PHP errors.
